### PR TITLE
in_state should be updated to midi_wait_status before midiCallbacks.

### DIFF
--- a/hardware/libraries/MD/MDPattern.cpp
+++ b/hardware/libraries/MD/MDPattern.cpp
@@ -87,197 +87,226 @@ bool MDPattern::fromSysex(uint8_t *data, uint16_t len) {
 #endif
     return false;
   }
-
+  
   isExtraPattern = (len == (0x1521 - 6));
   
   if (!ElektronHelper::checkSysexChecksum(data, len)) {
     return false;
   }
-
+  
   origPosition = data[3];
   ElektronSysexDecoder decoder(DATA_ENCODER_INIT(data + 0xA - 6, 74));
   decoder.get32(trigPatterns, 16);
-
+  
   decoder.start7Bit();
   decoder.get32(lockPatterns, 16);
-
+  
   decoder.start7Bit();
-  decoder.get32(&accentPattern, 4);
-  /*
-    accentPattern = decoder.gget32();
-    slidePattern  = decoder.gget32();
-    swingPattern  = decoder.gget32();
-    swingAmount   = decoder.gget32();
-  */
-  decoder.stop7Bit();
-	
-  decoder.get(&accentAmount, 6);
-  /*
-    accentAmount  = decoder.gget8();
-    patternLength = decoder.gget8();
-    doubleTempo   = decoder.gget8();
-    scale         = decoder.gget8();
-    kit           = decoder.gget8();
-    numLockedRows = decoder.gget8();
-  */
+    
+    decoder.get32(&accentPattern);
 
+    decoder.get32(&slidePattern);
+  decoder.get32(&swingPattern);
+
+    decoder.get32(&swingAmount);
+
+  /*
+   accentPattern = decoder.gget32();
+   slidePattern  = decoder.gget32();
+   swingPattern  = decoder.gget32();
+   swingAmount   = decoder.gget32();
+   */
+  decoder.stop7Bit();
+  
+    
+    
+  
+   accentAmount  = decoder.gget8();
+   patternLength = decoder.gget8();
+   doubleTempo   = decoder.gget8();
+   scale         = decoder.gget8();
+   kit           = decoder.gget8();
+   numLockedRows = decoder.gget8();
+   
+  
   decoder.start7Bit();
   for (uint8_t i = 0; i < 64; i++) {
     decoder.get(locks[i], 32);
   }
-
+  
   decoder.start7Bit();
-  decoder.get32(&accentEditAll, 3 + 16 * 3);
-#if 0
-  accentEditAll = decoder.gget32();
-  slideEditAll  = decoder.gget32();
-  swingEditAll  = decoder.gget32();
+  decoder.get32(&accentEditAll);
+    decoder.get32(&slideEditAll);
+    decoder.get32(&swingEditAll);
   decoder.get32(accentPatterns, 16);
   decoder.get32(slidePatterns, 16);
   decoder.get32(swingPatterns, 16);
-#endif
-
+  
   numRows = 0;
   for (int i = 0; i < 16; i++) {
     for (int j = 0; j < 24; j++) {
       if (IS_BIT_SET32(lockPatterns[i], j)) {
-	paramLocks[i][j] = numRows;
-	lockTracks[numRows] = i;
-	lockParams[numRows] = j;
-	numRows++;
+        paramLocks[i][j] = numRows;
+        lockTracks[numRows] = i;
+        lockParams[numRows] = j;
+        numRows++;
       }
     }
   }
-
+  
   if (isExtraPattern) {
     decoder.start7Bit();
     decoder.get32hi(trigPatterns, 16);
-    decoder.get32hi(&accentPattern, 3);
-    /*
-      decoder.get32hi(&slidePattern);
-      decoder.get32hi(&swingPattern);
-    */
+    decoder.get32hi(&accentPattern);
+    
+     decoder.get32hi(&slidePattern);
+     decoder.get32hi(&swingPattern);
+     
     for (uint8_t i = 0; i < 64; i++) {
       decoder.get(locks[i] + 32, 32);
     }
-    decoder.get32hi(accentPatterns, 16 * 3);
-    //		decoder.get32hi(slidePatterns, 16);
-    //		decoder.get32hi(swingPatterns, 16);
+          decoder.get32hi(accentPatterns, 16);
+          decoder.get32hi(slidePatterns, 16);
+        decoder.get32hi(swingPatterns, 16);
   }
-
+  
   return true;
 }
 
 uint16_t MDPattern::toSysex(uint8_t *data, uint16_t len) {
   ElektronDataToSysexEncoder encoder(DATA_ENCODER_INIT(data, len));
-
+  
   isExtraPattern = patternLength > 32;
   uint16_t sysexLength = isExtraPattern ? 0x151d : 0xac6;
-
+  
   if (len < (sysexLength + 5))
     return 0;
-
+  
   return toSysex(encoder);
 }
 
 uint16_t MDPattern::toSysex(ElektronDataToSysexEncoder &encoder) {
   isExtraPattern = patternLength > 32;
-
+  
   cleanupLocks();
   recalculateLockPatterns();
+  
 
+    /*
+    int8_t paramLocks_[16][24];
+    uint8_t locks_[64][64];
+    int8_t lockTracks_[64];
+    int8_t lockParams_[64];
+    
+    numRows = 0;
+    for (int i = 0; i < 16; i++) {
+        for (int j = 0; j < 24; j++) {
+            if (IS_BIT_SET32(lockPatterns[i], j)) {
+                paramLocks_[i][j] = numRows;
+                lockTracks_[numRows] = i;
+                lockParams_[numRows] = j;
+                paramLocks_[i][j] = numRows;
+                int idx_ = paramLocks[i][j];
+                for (int k = 0; k < 64; k++) {
+                    locks_[k][numRows] = locks[k][idx_];
+                }
+                numRows++;
+            }
+        }
+    }
+     */
   uint16_t sysexLength = isExtraPattern ? 0x151d : 0xac6;
-
+  
   encoder.stop7Bit();
   encoder.pack8(0xF0);
   encoder.pack(machinedrum_sysex_hdr, sizeof(machinedrum_sysex_hdr));
   encoder.pack8(MD_PATTERN_MESSAGE_ID);
   encoder.pack8(0x03); // version
   encoder.pack8(0x01);
-
+  
   encoder.startChecksum();
   encoder.pack8(origPosition);
-
+  
   encoder.start7Bit();
   encoder.pack32(trigPatterns, 16);
   encoder.reset();
   encoder.pack32(lockPatterns, 16);
   encoder.reset();
-
-  encoder.pack32(&accentPattern, 4);
-  /*
-    encoder.pack32(slidePattern);
-    encoder.pack32(swingPattern);
-    encoder.pack32(swingAmount);
-  */
+  
+  encoder.pack32(accentPattern);
+  
+   encoder.pack32(slidePattern);
+   encoder.pack32(swingPattern);
+   encoder.pack32(swingAmount);
+   
   encoder.stop7Bit();
-
-  encoder.pack(&accentAmount, 6);
-  /*
-    encoder.pack8(patternLength);
-    encoder.pack8(doubleTempo);
-    encoder.pack8(scale);
-    encoder.pack8(kit);
-    encoder.pack8(numLockedRows);
-  */
-
+  
+  encoder.pack8(accentAmount);
+  
+   encoder.pack8(patternLength);
+   encoder.pack8(doubleTempo);
+   encoder.pack8(scale);
+   encoder.pack8(kit);
+   encoder.pack8(numLockedRows);
+   
+  
   encoder.start7Bit();
-
+  
   uint8_t lockIdx = 0;
   for (uint8_t track = 0; track < 16; track++) {
     for (uint8_t param = 0; param < 24; param++) {
       int8_t lock = paramLocks[track][param];
       if ((lock != -1) && (lockIdx < 64)) {
-	encoder.pack(locks[lock], 32);
-	lockIdx++;
+        encoder.pack(locks[lock], 32);
+        lockIdx++;
       }
     }
   }
   encoder.fill8(0xFF, 32 * (64 - lockIdx));
   encoder.reset(); // reset 7 bit
-
-  encoder.pack32(&accentEditAll, 3 * 16 + 3);
-  /*
-    encoder.pack32(slideEditAll);
-    encoder.pack32(swingEditAll);
-
-    encoder.pack32(accentPatterns, 16);
-    encoder.pack32(slidePatterns, 16);
-    encoder.pack32(swingPatterns, 16);
-  */
-
+  
+  encoder.pack32(accentEditAll);
+  
+   encoder.pack32(slideEditAll);
+   encoder.pack32(swingEditAll);
+   
+   encoder.pack32(accentPatterns, 16);
+   encoder.pack32(slidePatterns, 16);
+   encoder.pack32(swingPatterns, 16);
+   
+  
   encoder.finish();
-	
+  
   if (isExtraPattern) {
     encoder.start7Bit();
     encoder.pack32hi(trigPatterns, 16);
-    encoder.pack32hi(&accentPattern, 3);
-    /*
-      encoder.pack32hi(slidePattern);
-      encoder.pack32hi(swingPattern);
-    */
-
+    encoder.pack32hi(accentPattern);
+    
+     encoder.pack32hi(slidePattern);
+     encoder.pack32hi(swingPattern);
+     
+    
     lockIdx = 0;
     for (uint8_t track = 0; track < 16; track++) {
       for (uint8_t param = 0; param < 24; param++) {
-	int8_t lock = paramLocks[track][param];
-	if ((lock != -1) && (lockIdx < 64)) {
-	  encoder.pack(locks[lock] + 32, 32);
-	  lockIdx++;
-	}
+        int8_t lock = paramLocks[track][param];
+        if ((lock != -1) && (lockIdx < 64)) {
+          encoder.pack(locks[lock] + 32, 32);
+          lockIdx++;
+        }
       }
     }
     encoder.fill8(0xFF, 32 * (64 - lockIdx));
-    encoder.pack32hi(accentPatterns, 16 * 3);
-    /*
-      encoder.pack32hi(slidePatterns, 16);
-      encoder.pack32hi(swingPatterns, 16);
-    */
+    encoder.pack32hi(accentPatterns, 16);
+    
+     encoder.pack32hi(slidePatterns, 16);
+     encoder.pack32hi(swingPatterns, 16);
+     
     encoder.finish();
   }
-
+  
   encoder.finishChecksum();
-
+  
   return sysexLength + 5;
 }
 

--- a/hardware/libraries/Midi/Midi.cpp
+++ b/hardware/libraries/Midi/Midi.cpp
@@ -153,11 +153,11 @@ void MidiClass::handleByte(uint8_t byte) {
     if (midi_parse[callback].midi_status == MIDI_NOTE_ON && msg[2] == 0) {
       callback = 0; // XXX ugly hack to recgnize NOTE on with velocity 0 as Note Off
     }
+    in_state = midi_wait_status;
 
 #ifdef HOST_MIDIDUINO
     messageCallback.call(msg, in_msg_len);
 #endif
-		
     if (callback < 7) {
       midiCallbacks[callback].call(msg);
 #if 0
@@ -176,7 +176,6 @@ void MidiClass::handleByte(uint8_t byte) {
 #endif
     }
 		
-    in_state = midi_wait_status;
     break;
 
   case midi_wait_byte_2:

--- a/hardware/libraries/Midi/TurboMidi.hh
+++ b/hardware/libraries/Midi/TurboMidi.hh
@@ -90,8 +90,8 @@ public:
   static const uint16_t speeds =
     _BV(TURBOMIDI_SPEED_1x)
     | _BV(TURBOMIDI_SPEED_2x)
-    //| _BV(TURBOMIDI_SPEED_3_33x)
-    //| _BV(TURBOMIDI_SPEED_4x)
+    | _BV(TURBOMIDI_SPEED_3_33x)
+    | _BV(TURBOMIDI_SPEED_4x)
     //		| _BV(TURBOMIDI_SPEED_5x)
     //		| _BV(TURBOMIDI_SPEED_6_66x)
     //		| _BV(TURBOMIDI_SPEED_8x)
@@ -100,8 +100,8 @@ public:
   static const uint16_t certifiedSpeeds =
     _BV(TURBOMIDI_SPEED_1x)
     | _BV(TURBOMIDI_SPEED_2x)
-    //| _BV(TURBOMIDI_SPEED_3_33x)
-    //| _BV(TURBOMIDI_SPEED_4x) 
+    | _BV(TURBOMIDI_SPEED_3_33x)
+    | _BV(TURBOMIDI_SPEED_4x) 
     //		| _BV(TURBOMIDI_SPEED_5x)
     //		| _BV(TURBOMIDI_SPEED_6_66x)
     //		| _BV(TURBOMIDI_SPEED_8x)

--- a/hardware/libraries/Midi/TurboMidi.hh
+++ b/hardware/libraries/Midi/TurboMidi.hh
@@ -90,8 +90,8 @@ public:
   static const uint16_t speeds =
     _BV(TURBOMIDI_SPEED_1x)
     | _BV(TURBOMIDI_SPEED_2x)
-    | _BV(TURBOMIDI_SPEED_3_33x)
-    | _BV(TURBOMIDI_SPEED_4x)
+    //| _BV(TURBOMIDI_SPEED_3_33x)
+    //| _BV(TURBOMIDI_SPEED_4x)
     //		| _BV(TURBOMIDI_SPEED_5x)
     //		| _BV(TURBOMIDI_SPEED_6_66x)
     //		| _BV(TURBOMIDI_SPEED_8x)
@@ -100,8 +100,8 @@ public:
   static const uint16_t certifiedSpeeds =
     _BV(TURBOMIDI_SPEED_1x)
     | _BV(TURBOMIDI_SPEED_2x)
-    | _BV(TURBOMIDI_SPEED_3_33x)
-    | _BV(TURBOMIDI_SPEED_4x) 
+    //| _BV(TURBOMIDI_SPEED_3_33x)
+    //| _BV(TURBOMIDI_SPEED_4x) 
     //		| _BV(TURBOMIDI_SPEED_5x)
     //		| _BV(TURBOMIDI_SPEED_6_66x)
     //		| _BV(TURBOMIDI_SPEED_8x)


### PR DESCRIPTION
If midi data was received during a callback the data could be missed,
repeated or corrupt.

Scenario: Midi NoteOn message/callback triggers SYSEX dump. The Sysex messages
would not be processed correctly because the in_state was still in
midi_wait_byte_1
